### PR TITLE
iPhone XS support / 在微信开发环境的全部机型均测试通过

### DIFF
--- a/calendar/calendar.wxss
+++ b/calendar/calendar.wxss
@@ -37,12 +37,14 @@
   flex-wrap: wrap;
   justify-content: center;
   width: 100%;
+  max-width: 504rpx;
+  margin: 0 auto;
 }
 .day {
   width: 40rpx;
   height: 40rpx;
   text-align: center;
-  padding: 4px 4px;
+  padding: 4rpx 4rpx;
   margin: 6rpx 12rpx;
   font-size: 27rpx;
   line-height: 40rpx;


### PR DESCRIPTION
iPhone XS support.

在以下机型均测试通过：

1. iPhone 5(320 X 568 Dpr: 2)
2. iPhone6/7/8(375X667|Dpr:2)
3. iPhone 6/7/8 Plus(414 x 736 Dpr: 3
4. iPhone X(375 x 812 Dpr: 3)
5. iPhone XR(414 x 896 Dpr: 2)
6. iPhone XS Max(414 x 896 Dpr: 3)
7. iPhone 12 mini(375 x 812 Dpr: 3)
8. Phone 12(390 X 844 Dpr: 3)
9. iPhone 12 Pro Max (428 x 926 Dpr: 3)
10. Nexus 5(360 X 640 Dpr: 3)
11. Nexus5X(411X731|Dpr:2625)
12. Nexus6(412X732|Dpr:3.5)
13. Windows(480 x 800 Dpr: 2)
14. Mac 13-inch and below(375 x 667 Dpr: 2
15. Mac 15-inch(375 X 736 Dpr: 2)
16. Mac 21-inch and above (414 x 896 Dpr: 2)
17. iPad(768X1024|Dpr:2)
18. iPad Pro 10.5-inch(834 x 1112 Dpr: 2)
19. iPad Pro 129-inch (1024 x 1366 Dpr: 2
20. iPhone11(828 X 1792 Dpr: 2)
21. P30(1080X2340|Dpr:2)
22. iPhoneXs(1125×2436|Dpr:2)